### PR TITLE
Extend tests coverage for CompilerClassloaderUtils

### DIFF
--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/main/java/org/kie/workbench/common/services/backend/compiler/impl/utils/JGitUtils.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/main/java/org/kie/workbench/common/services/backend/compiler/impl/utils/JGitUtils.java
@@ -34,7 +34,7 @@ public class JGitUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(JGITCompilerBeforeDecorator.class);
     private static String REMOTE = "origin";
-    private static String TEMP = System.getProperty("java.io.tmpdir") + File.separatorChar + "maven/";
+    private static String TEMP = System.getProperty("java.io.tmpdir") + File.separatorChar + "maven" + File.separatorChar;
 
     public static Boolean pullAndRebase(final Git git) {
         Boolean result = Boolean.FALSE;

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/classloader/CompilerClassloaderUtilsTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/classloader/CompilerClassloaderUtilsTest.java
@@ -61,6 +61,20 @@ public class CompilerClassloaderUtilsTest extends BaseCompilerTest {
     }
 
     @Test
+    public void filterSubClassesByPackage(){
+        List<String> targets = new ArrayList<>(4);
+        targets.add("/target/classes/org/kie/test/A.class");
+        targets.add("/target/classes/org/kie/test/child/B.class");
+        targets.add("/target/classes/org/kie/test/child/son/C.class");
+        targets.add("/target/classes/org/kie-test/T.class");
+
+        List<String> orgKie =  CompilerClassloaderUtils.filterClassesByPackage(targets, "org.kie");
+        assertThat(orgKie).hasSize(3)
+                .containsExactlyInAnyOrder("org.kie.test.A","org.kie.test.child.B","org.kie.test.child.son.C")
+                .doesNotContain("org.kie-test/T");
+    }
+
+    @Test
     public void filterPathClasses() {
         List<String> targets = new ArrayList<>(3);
         targets.add("/target/classes/org/kie/test/A.class");
@@ -71,7 +85,7 @@ public class CompilerClassloaderUtilsTest extends BaseCompilerTest {
         targets.add(mavenRepo.toAbsolutePath().toString() + "/junit/junit/4.12/junit-4.12.jar");
 
         Set<String> orgKie = CompilerClassloaderUtils.filterPathClasses(targets, mavenRepo.toString());
-        assertThat(orgKie.size() == 4).isTrue();
+        assertThat(orgKie).hasSize(4);
     }
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/classloader/CompilerClassloaderUtilsTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/classloader/CompilerClassloaderUtilsTest.java
@@ -90,16 +90,28 @@ public class CompilerClassloaderUtilsTest extends BaseCompilerTest {
 
     @Test
     public void filterPathClasses() {
-        List<String> targets = new ArrayList<>(3);
+        List<String> targets = new ArrayList<>(6);
         targets.add("/target/classes/org/kie/test/A.class");
         targets.add("/target/classes/io/akka/test/C.class");
         targets.add("/target/classes/com/acme/test/D.class");
-        targets.add("/target/classes/com/acme/test/D.class");
+        targets.add("/target/classes/com/acme/test/E.class");
         targets.add(mavenRepo.toAbsolutePath().toString() + "/junit/junit/4.12/junit.jar");
         targets.add(mavenRepo.toAbsolutePath().toString() + "/junit/junit/4.12/junit-4.12.jar");
 
         Set<String> orgKie = CompilerClassloaderUtils.filterPathClasses(targets, mavenRepo.toString());
         assertThat(orgKie).hasSize(4);
+    }
+
+    @Test
+    public void filterPathSubClasses() {
+        List<String> targets = new ArrayList<>(4);
+        targets.add("/target/classes/org/kie/test/A.class");
+        targets.add("/target/classes/org/kie/test/child/B.class");
+        targets.add("/target/classes/org/kie/test/child/son/C.class");
+        targets.add("/target/classes/org/kie-test/T.class");
+
+        Set<String> orgKie = CompilerClassloaderUtils.filterPathClasses(targets, mavenRepo.toString());
+        assertThat(orgKie).hasSize(4).contains("org.kie.test","org.kie.test.child","org.kie.test.child.son", "org.kie-test");
     }
 
     @Test
@@ -131,8 +143,7 @@ public class CompilerClassloaderUtilsTest extends BaseCompilerTest {
 
     @Test
     public void createClassloaderFromCpFiles() {
-        assertThat(!res.getDependencies().isEmpty()).isTrue();
-        assertThat(res.getDependencies().size()).isEqualTo(4);
+        assertThat(res.getDependencies()).hasSize(4);
         Optional<ClassLoader> classLoader = CompilerClassloaderUtils.createClassloaderFromStringDeps(res.getDependencies());
         assertThat(classLoader.isPresent()).isTrue();
         assertThat(classLoader.get()).isNotNull();

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/classloader/CompilerClassloaderUtilsTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/classloader/CompilerClassloaderUtilsTest.java
@@ -75,6 +75,20 @@ public class CompilerClassloaderUtilsTest extends BaseCompilerTest {
     }
 
     @Test
+    public void filterFilesFromPackage() {
+        List<String> targets = new ArrayList<>(5);
+        targets.add("/target/classes/org/kie/test/A.class");
+        targets.add("/target/classes/org/kie/test/J.java");
+        targets.add("/target/classes/org/kie/test/T.txt");
+        targets.add("/target/classes/org/kie/test/P.properties");
+        targets.add("/target/classes/org/kie/test/X.xml");
+
+        List<String> orgKie = CompilerClassloaderUtils.filterClassesByPackage(targets, "org.kie");
+        assertThat(orgKie).hasSize(1)
+                .containsExactlyInAnyOrder("org.kie.test.A");
+    }
+
+    @Test
     public void filterPathClasses() {
         List<String> targets = new ArrayList<>(3);
         targets.add("/target/classes/org/kie/test/A.class");


### PR DESCRIPTION
2 test failures
* test filterSubClassesByPackage - when is filtering "org.kie" then is class from package "org.kie-test" added too.
* test filterFilesFromPackage - into result list are added files. Only classes should be added
